### PR TITLE
Add option to randomize face colors (adds a random y rotation) - useful for F2L

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,6 +309,15 @@
                   <span class="ml-2 text-gray-900 dark:text-white">Random AUF</span>
                 </label>
               </div>
+              
+              <div class="flex items-center mb-4 text-sm sm:text-base max-w-[250px]">
+                <label for="random-colors-toggle" class="relative inline-flex items-center cursor-pointer">
+                  <input type="checkbox" id="random-colors-toggle" class="sr-only" />
+                  <div class="w-11 h-6 bg-gray-200 rounded-full shadow-inner"></div>
+                  <div class="dot absolute left-1 top-1 w-4 h-4 bg-white rounded-full shadow transition-transform duration-200 ease-in-out"></div>
+                  <span class="ml-2 text-gray-900 dark:text-white">Random Colors</span>
+                </label>
+              </div>
 
               <div class="flex items-center mb-4 text-sm sm:text-base max-w-[250px]">
                 <label for="random-order-toggle" class="relative inline-flex items-center cursor-pointer">

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,13 @@ function drawAlgInCube() {
       }
     }
   }
+  if (randomizeColors && scrambleToAlg.length == 0) {
+    let rotations = [[], ["y"], ["y", "y"], ["y'"]]
+    let randomRot = rotations[Math.floor(Math.random() * rotations.length)];
+    //if (randomRot != "") { userAlg.concat(randomRot); }
+    userAlg = userAlg.concat(randomRot);
+    //userAlg = [randomRot].concat(userAlg); } //userAlg.push(randomRot); }
+  }
   if (randomizeAUF && scrambleToAlg.length > 0) {
     userAlg = [...scrambleToAlg];
     $('#alg-display').text(userAlg.join(' '));
@@ -1606,6 +1613,13 @@ const randomAUFToggle = document.getElementById('random-auf-toggle') as HTMLInpu
 randomAUFToggle.addEventListener('change', () => {
   randomizeAUF = randomAUFToggle.checked;
 });
+
+let randomizeColors: boolean = false;
+const randomColorsToggle = document.getElementById('random-colors-toggle') as HTMLInputElement;
+randomColorsToggle.addEventListener('change', () => {
+  randomizeColors = randomColorsToggle.checked;
+});
+
 
 // Add event listener for the prioritize slow toggle
 let prioritizeSlowAlgs: boolean = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,11 +225,9 @@ function drawAlgInCube() {
     }
   }
   if (randomizeColors && scrambleToAlg.length == 0) {
-    let rotations = [[], ["y"], ["y", "y"], ["y'"]]
+    let rotations = [[], ["y"], ["y2"], ["y'"]]
     let randomRot = rotations[Math.floor(Math.random() * rotations.length)];
-    //if (randomRot != "") { userAlg.concat(randomRot); }
     userAlg = userAlg.concat(randomRot);
-    //userAlg = [randomRot].concat(userAlg); } //userAlg.push(randomRot); }
   }
   if (randomizeAUF && scrambleToAlg.length > 0) {
     userAlg = [...scrambleToAlg];


### PR DESCRIPTION
This adds an option to randomize the initial orientation of the cube for algo drilling.  For things like F2L this helps drill my recognition of the cases better.

Two notes:
1) Let me know if there is a better way to achieve this - I just added a random set of y rotations to the userAlg at the end

2) I'll probably add a "color neutral" option later on, which would be very similar just not restricted to y rotations - to that end I"m not sure if "randomize colors" is a confusing naming / people will think this means color neutral.