### PR TITLE
Add separate algo categories for each f2l location for ease of use

### DIFF
--- a/src/defaultAlgs.json
+++ b/src/defaultAlgs.json
@@ -1176,6 +1176,790 @@
       ]
     }
   ],
+  "F2L Front Right": [
+    {
+      "subset": "Free Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 1",
+          "algorithm": "U R U' R'"
+        },
+        {
+          "name": "F2L 2",
+          "algorithm": "F R' F' R"
+        },
+        {
+          "name": "F2L 3",
+          "algorithm": "F' U' F"
+        },
+        {
+          "name": "F2L 4",
+          "algorithm": "R U R'"
+        }
+      ]
+    },
+    {
+      "subset": "Connected Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 11",
+          "algorithm": "U' R U2 R' U F' U' F"
+        },
+        {
+          "name": "F2L 12",
+          "algorithm": "R U' R' U R U' R' U2 R U' R'"
+        },
+        {
+          "name": "F2L 13",
+          "algorithm": "M' U' R U R' U2 R U' r'"
+        },
+        {
+          "name": "F2L 14",
+          "algorithm": "U' R U' R' U R U R'"
+        },
+        {
+          "name": "F2L 15",
+          "algorithm": "R' D' R U' R' D R U R U' R'"
+        },
+        {
+          "name": "F2L 16",
+          "algorithm": "R U' R' U2 F' U' F"
+        },
+        {
+          "name": "F2L 17",
+          "algorithm": "R U2 R' U' R U R'"
+        },
+        {
+          "name": "F2L 18",
+          "algorithm": "R' F R F' R U' R' U R U' R'"
+        },
+        {
+          "name": "F2L 23",
+          "algorithm": "U R U' R' U' R U' R' U R U' R'"
+        },
+        {
+          "name": "F2L 24",
+          "algorithm": "F U R U' R' F' R U' R'"
+        }
+      ]
+    },
+    {
+      "subset": "Corner in slot",
+      "algorithms": [
+        {
+          "name": "F2L 25",
+          "algorithm": "U' R' F R F' R U R'"
+        },
+        {
+          "name": "F2L 26",
+          "algorithm": "U R U' R' F R' F' R"
+        },
+        {
+          "name": "F2L 27",
+          "algorithm": "R U' R' U R U' R'"
+        },
+        {
+          "name": "F2L 28",
+          "algorithm": "R U R' U' F R' F' R"
+        },
+        {
+          "name": "F2L 29",
+          "algorithm": "R' F R F' U R U' R'"
+        },
+        {
+          "name": "F2L 30",
+          "algorithm": "R U R' U' R U R'"
+        }
+      ]
+    },
+    {
+      "subset": "Edge in slot",
+      "algorithms": [
+        {
+          "name": "F2L 31",
+          "algorithm": "U' R' F R F' R U' R'"
+        },
+        {
+          "name": "F2L 32",
+          "algorithm": "U R U' R' U R U' R' U R U' R'"
+        },
+        {
+          "name": "F2L 33",
+          "algorithm": "U' R U' R' U2 R U' R'"
+        },
+        {
+          "name": "F2L 34",
+          "algorithm": "U R U R' U2 R U R'"
+        },
+        {
+          "name": "F2L 35",
+          "algorithm": "U' R U R' U F' U' F"
+        },
+        {
+          "name": "F2L 36",
+          "algorithm": "U F' U' F U' R U R'"
+        }
+      ]
+    },
+    {
+      "subset": "Both in slot",
+      "algorithms": [
+        {
+          "name": "F2L 37",
+          "algorithm": "R2 U2 F R2 F' U2 R' U R'"
+        },
+        {
+          "name": "F2L 38",
+          "algorithm": "R U' R' U' R U R' U2 R U' R'"
+        },
+        {
+          "name": "F2L 39",
+          "algorithm": "R U' R' U R U2 R' U R U' R'"
+        },
+        {
+          "name": "F2L 40",
+          "algorithm": "r U' r' U2 r U r' R U R'"
+        },
+        {
+          "name": "F2L 41",
+          "algorithm": "R U' R' r U' r' U2 r U r'"
+        }
+      ]
+    },
+    {
+      "subset": "Split Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 5",
+          "algorithm": "U' R U R' U2 R U' R'"
+        },
+        {
+          "name": "F2L 6",
+          "algorithm": "U' r U' R' U R U r'"
+        },
+        {
+          "name": "F2L 7",
+          "algorithm": "U' R U2 R' U' R U2 R'"
+        },
+        {
+          "name": "F2L 8",
+          "algorithm": "d R' U2 R U R' U2 R"
+        },
+        {
+          "name": "F2L 9",
+          "algorithm": "U' R U' R' U F' U' F"
+        },
+        {
+          "name": "F2L 10",
+          "algorithm": "U' R U R' U R U R'"
+        },
+        {
+          "name": "F2L 19",
+          "algorithm": "U R U2 R' U R U' R'"
+        },
+        {
+          "name": "F2L 20",
+          "algorithm": "U' R U' R2 F R F' R U' R'"
+        },
+        {
+          "name": "F2L 21",
+          "algorithm": "U2 R U R' U R U' R'"
+        },
+        {
+          "name": "F2L 22",
+          "algorithm": "r U' r' U2 r U r'"
+        }
+      ]
+    }
+  ],
+  "F2L Front Left": [
+    {
+      "subset": "Free Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 1",
+          "algorithm": "F' L F L'"
+        },
+        {
+          "name": "F2L 2",
+          "algorithm": "U' L' U L"
+        },
+        {
+          "name": "F2L 3",
+          "algorithm": "L' U' L"
+        },
+        {
+          "name": "F2L 4",
+          "algorithm": "F U F'"
+        }
+      ]
+    },
+    {
+      "subset": "Connected Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 11",
+          "algorithm": "L' U L U' L' U L U2 L' U L"
+        },
+        {
+          "name": "F2L 12",
+          "algorithm": "U L' U2 L U' F U F'"
+        },
+        {
+          "name": "F2L 13",
+          "algorithm": "U L' U L U' L' U' L"
+        },
+        {
+          "name": "F2L 14",
+          "algorithm": "d' L U' L' U L U L'"
+        },
+        {
+          "name": "F2L 15",
+          "algorithm": "L' U L U2 F U F'"
+        },
+        {
+          "name": "F2L 16",
+          "algorithm": "F U' R U' R' U2 F'"
+        },
+        {
+          "name": "F2L 17",
+          "algorithm": "L F' L' F L' U L U' L' U L"
+        },
+        {
+          "name": "F2L 18",
+          "algorithm": "L' U2 L U L' U' L"
+        },
+        {
+          "name": "F2L 23",
+          "algorithm": "F' U' L' U L F L' U L"
+        },
+        {
+          "name": "F2L 24",
+          "algorithm": "U' F' r U r' U' L' U' L"
+        }
+      ]
+    },
+    {
+      "subset": "Corner in slot",
+      "algorithms": [
+        {
+          "name": "F2L 25",
+          "algorithm": "U' L' U L F' r U r'"
+        },
+        {
+          "name": "F2L 26",
+          "algorithm": "r U r' U' r' F r F'"
+        },
+        {
+          "name": "F2L 27",
+          "algorithm": "L' U' L U F' r U r'"
+        },
+        {
+          "name": "F2L 28",
+          "algorithm": "L' U L U' L' U L"
+        },
+        {
+          "name": "F2L 29",
+          "algorithm": "L' U' L U L' U' L"
+        },
+        {
+          "name": "F2L 30",
+          "algorithm": "L F' L' F U' L' U L"
+        }
+      ]
+    },
+    {
+      "subset": "Edge in slot",
+      "algorithms": [
+        {
+          "name": "F2L 31",
+          "algorithm": "U L F' L' F L' U L"
+        },
+        {
+          "name": "F2L 32",
+          "algorithm": "U' L' U L U' L' U L U' L' U L"
+        },
+        {
+          "name": "F2L 33",
+          "algorithm": "R' D R U' R' D' R"
+        },
+        {
+          "name": "F2L 34",
+          "algorithm": "U L' U L U L' U2 L"
+        },
+        {
+          "name": "F2L 35",
+          "algorithm": "U2 L F' L' F U2 L' U' L"
+        },
+        {
+          "name": "F2L 36",
+          "algorithm": "U2 L' U L U F U F'"
+        }
+      ]
+    },
+    {
+      "subset": "Both in slot",
+      "algorithms": [
+        {
+          "name": "F2L 37",
+          "algorithm": "L2 U2 F' L2 F U2 L U' L"
+        },
+        {
+          "name": "F2L 38",
+          "algorithm": "L' U L U' L' U2 L U' L' U L"
+        },
+        {
+          "name": "F2L 39",
+          "algorithm": "L' U L U L' U' L U2 L' U L"
+        },
+        {
+          "name": "F2L 40",
+          "algorithm": "L' U L F R U2 R' F'"
+        },
+        {
+          "name": "F2L 41",
+          "algorithm": "l' U l U2 l' U' l L' U' L"
+        }
+      ]
+    },
+    {
+      "subset": "Split Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 5",
+          "algorithm": "U R' F r U' r' F' R"
+        },
+        {
+          "name": "F2L 6",
+          "algorithm": "F2 R U R' U' F2"
+        },
+        {
+          "name": "F2L 7",
+          "algorithm": "F U R U2 R' U F'"
+        },
+        {
+          "name": "F2L 8",
+          "algorithm": "U L' U2 L U L' U2 L"
+        },
+        {
+          "name": "F2L 9",
+          "algorithm": "U L' U' L U' L' U' L"
+        },
+        {
+          "name": "F2L 10",
+          "algorithm": "F U' R U R' U2 F'"
+        },
+        {
+          "name": "F2L 19",
+          "algorithm": "U L' U L2 F' L' F L' U L"
+        },
+        {
+          "name": "F2L 20",
+          "algorithm": "U' L' U2 L U' L' U L"
+        },
+        {
+          "name": "F2L 21",
+          "algorithm": "l' U l U2 l' U' l"
+        },
+        {
+          "name": "F2L 22",
+          "algorithm": "L' U L U2 L' U' L"
+        }
+      ]
+    }
+  ],
+  "F2L Back Right": [
+    {
+      "subset": "Free Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 1",
+          "algorithm": "U f R' f'"
+        },
+        {
+          "name": "F2L 2",
+          "algorithm": "U' R' U R"
+        },
+        {
+          "name": "F2L 3",
+          "algorithm": "R' U' R"
+        },
+        {
+          "name": "F2L 4",
+          "algorithm": "f R f'"
+        }
+      ]
+    },
+    {
+      "subset": "Connected Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 11",
+          "algorithm": "R' U R U' R' U R U2 R' U R"
+        },
+        {
+          "name": "F2L 12",
+          "algorithm": "U R' U2 R U' f R f'"
+        },
+        {
+          "name": "F2L 13",
+          "algorithm": "U R' U R U' R' U' R"
+        },
+        {
+          "name": "F2L 14",
+          "algorithm": "d' R U' R' U R U R'"
+        },
+        {
+          "name": "F2L 15",
+          "algorithm": "R' U R U2 f R f'"
+        },
+        {
+          "name": "F2L 16",
+          "algorithm": "R' U' R U2 R' U R U' R' U R"
+        },
+        {
+          "name": "F2L 17",
+          "algorithm": "R' U2 F R U R' U' F' R"
+        },
+        {
+          "name": "F2L 18",
+          "algorithm": "R' U2 R U R' U' R"
+        },
+        {
+          "name": "F2L 23",
+          "algorithm": "U R' F R' F' R2 U' R' U R"
+        },
+        {
+          "name": "F2L 24",
+          "algorithm": "R' U' R U2 R' U' R U R' U' R"
+        }
+      ]
+    },
+    {
+      "subset": "Corner in slot",
+      "algorithms": [
+        {
+          "name": "F2L 25",
+          "algorithm": "U' R' U M U' R U M'"
+        },
+        {
+          "name": "F2L 26",
+          "algorithm": "R' U R U R' U R U' R' U' R"
+        },
+        {
+          "name": "F2L 27",
+          "algorithm": "R' U2 R' F R F' R"
+        },
+        {
+          "name": "F2L 28",
+          "algorithm": "R' U R U' R' U R"
+        },
+        {
+          "name": "F2L 29",
+          "algorithm": "R' U' R U R' U' R"
+        },
+        {
+          "name": "F2L 30",
+          "algorithm": "f R f' U' f R f'"
+        }
+      ]
+    },
+    {
+      "subset": "Edge in slot",
+      "algorithms": [
+        {
+          "name": "F2L 31",
+          "algorithm": "R' U R' F R F' R"
+        },
+        {
+          "name": "F2L 32",
+          "algorithm": "U' R' U R U' R' U R U' R' U R"
+        },
+        {
+          "name": "F2L 33",
+          "algorithm": "U' R D R' U R D' R'"
+        },
+        {
+          "name": "F2L 34",
+          "algorithm": "U R' U R U R' U2 R"
+        },
+        {
+          "name": "F2L 35",
+          "algorithm": "U' f R f' U R' U' R"
+        },
+        {
+          "name": "F2L 36",
+          "algorithm": "U2 R' U' R U R' F' U' F R"
+        }
+      ]
+    },
+    {
+      "subset": "Both in slot",
+      "algorithms": [
+        {
+          "name": "F2L 37",
+          "algorithm": "R' U R r U2 R2 U' R2 U' r'"
+        },
+        {
+          "name": "F2L 38",
+          "algorithm": "R' U' R U2 R' U R U' R' U' R"
+        },
+        {
+          "name": "F2L 39",
+          "algorithm": "R' U' R U R' U2 R U R' U' R"
+        },
+        {
+          "name": "F2L 40",
+          "algorithm": "R' U R r' U r U2 r' U' r"
+        },
+        {
+          "name": "F2L 41",
+          "algorithm": "r' U r U2 r' U' r R' U' R"
+        }
+      ]
+    },
+    {
+      "subset": "Split Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 5",
+          "algorithm": "U' R' F R U R' U' F' R"
+        },
+        {
+          "name": "F2L 6",
+          "algorithm": "U R' U' R U2 R' U R"
+        },
+        {
+          "name": "F2L 7",
+          "algorithm": "r U2 R2 U' R2 U' r'"
+        },
+        {
+          "name": "F2L 8",
+          "algorithm": "U R' U2 R U R' U2 R"
+        },
+        {
+          "name": "F2L 9",
+          "algorithm": "U R' U' R U' R' U' R"
+        },
+        {
+          "name": "F2L 10",
+          "algorithm": "R2 U' F' U F R2"
+        },
+        {
+          "name": "F2L 19",
+          "algorithm": "U R' F' U2 F R U R' U' R"
+        },
+        {
+          "name": "F2L 20",
+          "algorithm": "U' R' U2 R U' R' U R"
+        },
+        {
+          "name": "F2L 21",
+          "algorithm": "r' U r U2 r' U' r"
+        },
+        {
+          "name": "F2L 22",
+          "algorithm": "R' U R U2 R' U' R"
+        }
+      ]
+    }
+  ],
+  "F2L Back Left": [
+    {
+      "subset": "Free Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 1",
+          "algorithm": "U L U' L'"
+        },
+        {
+          "name": "F2L 2",
+          "algorithm": "d' R' U R"
+        },
+        {
+          "name": "F2L 3",
+          "algorithm": "f' L' f"
+        },
+        {
+          "name": "F2L 4",
+          "algorithm": "L U L'"
+        }
+      ]
+    },
+    {
+      "subset": "Connected Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 11",
+          "algorithm": "U' L U2 L' U f' L' f"
+        },
+        {
+          "name": "F2L 12",
+          "algorithm": "L U' L' U L U' L' U2 L U' L'"
+        },
+        {
+          "name": "F2L 13",
+          "algorithm": "d L' U L U' L' U' L"
+        },
+        {
+          "name": "F2L 14",
+          "algorithm": "U' L U' L' U L U L'"
+        },
+        {
+          "name": "F2L 15",
+          "algorithm": "L U L' U2 L U' L' U L U' L'"
+        },
+        {
+          "name": "F2L 16",
+          "algorithm": "L U' L' U2 f' L' f"
+        },
+        {
+          "name": "F2L 17",
+          "algorithm": "L U2 L' U' L U L'"
+        },
+        {
+          "name": "F2L 18",
+          "algorithm": "L U2 F' L' U' L U F L'"
+        },
+        {
+          "name": "F2L 23",
+          "algorithm": "L U L' U2 L U L' U' L U L'"
+        },
+        {
+          "name": "F2L 24",
+          "algorithm": "U2 r U R' U R U2 B r'"
+        }
+      ]
+    },
+    {
+      "subset": "Corner in slot",
+      "algorithms": [
+        {
+          "name": "F2L 25",
+          "algorithm": "R D' R' U' R D R' L U L'"
+        },
+        {
+          "name": "F2L 26",
+          "algorithm": "L S L' U L S' L'"
+        },
+        {
+          "name": "F2L 27",
+          "algorithm": "L U' L' U L U' L'"
+        },
+        {
+          "name": "F2L 28",
+          "algorithm": "L U2 L F' L' F L'"
+        },
+        {
+          "name": "F2L 29",
+          "algorithm": "U2 L U' L' f' L' f"
+        },
+        {
+          "name": "F2L 30",
+          "algorithm": "L U L' U' L U L'"
+        }
+      ]
+    },
+    {
+      "subset": "Edge in slot",
+      "algorithms": [
+        {
+          "name": "F2L 31",
+          "algorithm": "L U' L F' L' F L'"
+        },
+        {
+          "name": "F2L 32",
+          "algorithm": "L U L' U' L U L' U' L U L'"
+        },
+        {
+          "name": "F2L 33",
+          "algorithm": "U' L U' L' U2 L U' L'"
+        },
+        {
+          "name": "F2L 34",
+          "algorithm": "U L U L' U2 L U L'"
+        },
+        {
+          "name": "F2L 35",
+          "algorithm": "U2 L U L' U' L F U F' L'"
+        },
+        {
+          "name": "F2L 36",
+          "algorithm": "U f' L' f U' L U L'"
+        }
+      ]
+    },
+    {
+      "subset": "Both in slot",
+      "algorithms": [
+        {
+          "name": "F2L 37",
+          "algorithm": "L U' L' l' U2 L2 U L2 U l"
+        },
+        {
+          "name": "F2L 38",
+          "algorithm": "L U L' U' L U2 L' U' L U L'"
+        },
+        {
+          "name": "F2L 39",
+          "algorithm": "L U L' U2 L U' L' U L U L'"
+        },
+        {
+          "name": "F2L 40",
+          "algorithm": "l U' l' U2 l U l' L U L'"
+        },
+        {
+          "name": "F2L 41",
+          "algorithm": "L2 F U F' U' L' U L'"
+        }
+      ]
+    },
+    {
+      "subset": "Split Pairs",
+      "algorithms": [
+        {
+          "name": "F2L 5",
+          "algorithm": "U' L U L' U2 L U' L'"
+        },
+        {
+          "name": "F2L 6",
+          "algorithm": "U r U' r' U' L U F L'"
+        },
+        {
+          "name": "F2L 7",
+          "algorithm": "U' L U2 L' U2 L U' L'"
+        },
+        {
+          "name": "F2L 8",
+          "algorithm": "l' U2 L2 U L2 U l"
+        },
+        {
+          "name": "F2L 9",
+          "algorithm": "d L' U' L U' L' U' L"
+        },
+        {
+          "name": "F2L 10",
+          "algorithm": "U' L U L' U L U L'"
+        },
+        {
+          "name": "F2L 19",
+          "algorithm": "U L U2 L' U L U' L'"
+        },
+        {
+          "name": "F2L 20",
+          "algorithm": "d' R' U2 R U' R' U R"
+        },
+        {
+          "name": "F2L 21",
+          "algorithm": "L U' L' U2 L U L'"
+        },
+        {
+          "name": "F2L 22",
+          "algorithm": "l U' l' U2 l U l'"
+        }
+      ]
+    }
+  ],
   "WVLS": [
     {
       "subset": "0 Oriented",


### PR DESCRIPTION
I found this useful - this breaks out separate algo subcategories for the different f2l locations (front right, back right, etc) in order to make it easier to practice one location / avoid having to go through and manually select a large subset.